### PR TITLE
Added Warning message for the invalid project

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,8 @@ import { RunOptions, runAll } from './helpers/run';
 import { interactiveMode } from './helpers/interactive-mode';
 import { fileExists } from './helpers/file-exists';
 import { outro } from '@clack/prompts';
+import { isCorrectProject } from './helpers/validate-project';
+import { invalidProjectWarningMessage } from './helpers/invalid-project-warning';
 
 cli(
   {
@@ -83,7 +85,13 @@ cli(
     };
     try {
       if (!argv._.filePath || !argv.flags.test) {
-        await interactiveMode(runOptions);
+        const isCorrectFolderStructure = await isCorrectProject();
+
+        if (!isCorrectFolderStructure) {
+          await invalidProjectWarningMessage();
+        } else {
+          await interactiveMode(runOptions);
+        }
         return;
       }
 

--- a/src/helpers/invalid-project-warning.ts
+++ b/src/helpers/invalid-project-warning.ts
@@ -1,0 +1,49 @@
+import { dim, gray, yellow } from 'kolorist';
+import { exitOnCancel } from './exit-on-cancel';
+import { outro, text } from '@clack/prompts';
+import { execaCommand } from 'execa';
+import * as p from '@clack/prompts';
+
+export async function invalidProjectWarningMessage() {
+  console.warn(
+    yellow(
+      'Warning: The current directory does not appear to be a recognized project folder.'
+    )
+  );
+
+  const choice = await p.select({
+    message: 'Want to setup a new project' + ':',
+    options: [
+      {
+        label: 'Node + Vitest project',
+        value: 'node-vitest',
+      },
+      {
+        label: 'Exit',
+        value: 'cancel',
+      },
+    ],
+  });
+
+  if (choice === 'node-vitest') {
+    const command = `npm init -y && npm install typescript tsx @types/node vitest -D && npx tsc --init`;
+
+    console.log('');
+
+    console.log(dim(`Running: ${command}`));
+
+    await execaCommand(command, {
+      stdio: 'inherit',
+      shell: process.env.SHELL || true,
+    }).catch(() => {
+      // No need to handle, will go to stderr
+    });
+
+    process.exit();
+  } else if (choice === 'cancel') {
+    outro('Goodbye!');
+    process.exit(0);
+  }
+
+  process.exit();
+}

--- a/src/helpers/validate-project.ts
+++ b/src/helpers/validate-project.ts
@@ -1,0 +1,24 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export async function isCorrectProject(): Promise<boolean> {
+  const currentDir = process.cwd();
+  const packageJsonPath = path.join(currentDir, 'package.json');
+  const requirementsTxtPath = path.join(currentDir, 'requirements.txt');
+
+  try {
+    await fs.access(packageJsonPath);
+    return true;
+  } catch {
+    // Do nothing if file doesn't exist
+  }
+
+  try {
+    await fs.access(requirementsTxtPath);
+    return true;
+  } catch {
+    // Do nothing if file doesn't exist
+  }
+
+  return false;
+}


### PR DESCRIPTION
This pull request introduces functionality to warn/or assist to setup a new project if a user is not already in a folder that is clearly a project.

### Linked Issue

fixes #24 