### PR TITLE
fix: windows compatible unit tests

### DIFF
--- a/src/helpers/config.test.ts
+++ b/src/helpers/config.test.ts
@@ -37,6 +37,7 @@ const realProcess = process;
 global.process = { ...realProcess, exit: mocks.exit };
 
 const configFilePath = path.join(os.homedir(), '.micro-agent');
+const newline = os.platform() === 'win32' ? '\r\n' : '\n';
 
 describe('getConfig', () => {
   const defaultConfig = {
@@ -121,7 +122,7 @@ describe('getConfig', () => {
     };
     mocks.lstat.mockResolvedValueOnce(true);
     mocks.readFile.mockResolvedValueOnce(
-      'OPENAI_KEY=my-openai-key\nMODEL=gpt-3.5-turbo\nLANGUAGE=en\n'
+      `OPENAI_KEY=my-openai-key${newline}MODEL=gpt-3.5-turbo${newline}LANGUAGE=en${newline}`
     );
 
     const result = await getConfig();
@@ -161,7 +162,7 @@ describe('setConfigs', () => {
 
     expect(mocks.writeFile).toHaveBeenCalledWith(
       configFilePath,
-      'OPENAI_KEY=my-openai-key\nMODEL=gpt-3.5-turbo\nLANGUAGE=en\n',
+      `OPENAI_KEY=my-openai-key${newline}MODEL=gpt-3.5-turbo${newline}LANGUAGE=en${newline}`,
       'utf8'
     );
   });
@@ -262,7 +263,7 @@ describe('showConfigUI', () => {
     expect(mocks.writeFile).toHaveBeenCalledTimes(1);
     expect(mocks.writeFile).toHaveBeenCalledWith(
       configFilePath,
-      'OPENAI_KEY=my-openai-key\n',
+      `OPENAI_KEY=my-openai-key${newline}`,
       'utf8'
     );
   });
@@ -298,7 +299,7 @@ describe('showConfigUI', () => {
     expect(mocks.writeFile).toHaveBeenCalledTimes(1);
     expect(mocks.writeFile).toHaveBeenCalledWith(
       configFilePath,
-      'OPENAI_API_ENDPOINT=https://api.openai.com/v1\n',
+      `OPENAI_API_ENDPOINT=https://api.openai.com/v1${newline}`,
       'utf8'
     );
   });
@@ -330,7 +331,7 @@ describe('showConfigUI', () => {
     expect(mocks.writeFile).toHaveBeenCalledTimes(1);
     expect(mocks.writeFile).toHaveBeenCalledWith(
       configFilePath,
-      'MODEL=gpt-4o\n',
+      `MODEL=gpt-4o${newline}`,
       'utf8'
     );
   });

--- a/src/helpers/dependency-files.test.ts
+++ b/src/helpers/dependency-files.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { getDependencyFile, getDependencyFileName } from './dependency-files';
+import path from 'path';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -60,9 +61,9 @@ describe('getDependencyFile', () => {
 
     const result = await getDependencyFile('/src');
     expect(mocks.fileExists).toHaveBeenCalledTimes(3);
-    expect(mocks.fileExists).toHaveBeenCalledWith('/src/package.json');
-    expect(mocks.fileExists).toHaveBeenCalledWith('/src/requirements.txt');
-    expect(mocks.fileExists).toHaveBeenCalledWith('/src/Gemfile');
+    expect(mocks.fileExists).toHaveBeenCalledWith(path.join('/src', 'package.json'));
+    expect(mocks.fileExists).toHaveBeenCalledWith(path.join('/src', 'requirements.txt'));
+    expect(mocks.fileExists).toHaveBeenCalledWith(path.join('/src', 'Gemfile'));
   });
 
   it('should return null if package.json file does not exist', async () => {

--- a/src/helpers/dependency-files.test.ts
+++ b/src/helpers/dependency-files.test.ts
@@ -61,8 +61,12 @@ describe('getDependencyFile', () => {
 
     const result = await getDependencyFile('/src');
     expect(mocks.fileExists).toHaveBeenCalledTimes(3);
-    expect(mocks.fileExists).toHaveBeenCalledWith(path.join('/src', 'package.json'));
-    expect(mocks.fileExists).toHaveBeenCalledWith(path.join('/src', 'requirements.txt'));
+    expect(mocks.fileExists).toHaveBeenCalledWith(
+      path.join('/src', 'package.json')
+    );
+    expect(mocks.fileExists).toHaveBeenCalledWith(
+      path.join('/src', 'requirements.txt')
+    );
     expect(mocks.fileExists).toHaveBeenCalledWith(path.join('/src', 'Gemfile'));
   });
 

--- a/src/helpers/dependency-files.ts
+++ b/src/helpers/dependency-files.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs/promises';
+import { readFile } from 'fs/promises';
 import * as path from 'path';
 import { fileExists } from './file-exists';
 
@@ -11,7 +11,8 @@ export async function getDependencyFile(
   language?: string
 ): Promise<string | null> {
   let currentDirectory = directory;
-  while (currentDirectory !== '/') {
+  const rootDirectory = path.parse(directory).root;
+  while (currentDirectory !== rootDirectory || rootDirectory == '') {
     if (language) {
       const filePath = getDependenciesFilePath(directory, language);
 
@@ -63,6 +64,6 @@ async function getDependenciesFileContent(
   language?: string
 ): Promise<string> {
   const filePath = getDependenciesFilePath(directory, language);
-  const fileContent = await fs.readFile(filePath, 'utf8');
+  const fileContent = await readFile(filePath, 'utf8');
   return fileContent;
 }


### PR DESCRIPTION
This pull request includes changes to improve cross-platform compatibility and refactor file handling in the test suite. The most significant changes include adding platform-specific newline characters, refactoring path handling (path.join(...) handles the folder separator characters), and updating readFile import statement so that `vi.mock('fs/promises'...` works on Windows too.

Tested the changes by running `npm test` with both Windows (GitBash terminal) and on Linux via WSL.

Windows:
![image](https://github.com/user-attachments/assets/c586e4ca-1219-44a3-9b00-fd7408f81d3e)

Linux (via WSL):
![image](https://github.com/user-attachments/assets/d5cf3de6-20ca-4bcf-91d2-78ae0c92de18)
